### PR TITLE
Adapt to python 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 sensitive.txt 
+__pycache__

--- a/xmpparser.py
+++ b/xmpparser.py
@@ -47,7 +47,9 @@ class XmpParser(object):
         """ A dictionary of all the parsed metadata. """
         meta = defaultdict(dict)
         for desc in self.rdftree.findall(RDF_NS + 'Description'):
-            for el in desc.getchildren():
+            # modified for 3.9 
+            # for el in desc.getchildren():
+            for el in desc:
                 ns, tag = self._parse_tag(el)
                 value = self._parse_value(el)
                 meta[ns][tag] = value


### PR DESCRIPTION
Running under python 3.9 gives
> 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'

With my proposed change it works again. I tested that it still works under python 3.6.15 (But please note I  didn't test with previous)